### PR TITLE
Add middleware

### DIFF
--- a/contextvalue/contextvalue.go
+++ b/contextvalue/contextvalue.go
@@ -25,12 +25,12 @@ func Value[T any](ctx context.Context, key Key) (T, error) {
 	)
 
 	if v = ctx.Value(key); v == nil {
-		return *new(T), ErrNoValue
+		return vAsserted, ErrNoValue
 	}
 
 	if vAsserted, ok = v.(T); ok {
 		return vAsserted, nil
 	}
 
-	return *new(T), ErrAssertFailed
+	return vAsserted, ErrAssertFailed
 }

--- a/contextvalue/contextvalue_test.go
+++ b/contextvalue/contextvalue_test.go
@@ -2,6 +2,7 @@ package contextvalue
 
 import (
 	"context"
+	"errors"
 	"testing"
 )
 
@@ -10,7 +11,7 @@ var key Key = "hi"
 func TestNoValue(t *testing.T) {
 	ctx := context.Background()
 	_, err := Value[string](ctx, key)
-	if err != ErrNoValue {
+	if !errors.Is(err, ErrNoValue) {
 		t.Errorf("want ErrNoValue, got %v", err)
 	}
 }
@@ -20,7 +21,7 @@ func TestAssertFailed(t *testing.T) {
 
 	ctx := context.WithValue(context.Background(), key, value)
 	_, err := Value[int](ctx, "hi")
-	if err != ErrAssertFailed {
+	if !errors.Is(err, ErrAssertFailed) {
 		t.Errorf("want ErrAssertFailed, got %v", err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,12 @@
 module github.com/jrozner/weby
 
-go 1.22.3
+go 1.23
 
-require github.com/google/uuid v1.6.0
+toolchain go1.24.4
+
+require (
+	github.com/google/uuid v1.6.0
+	github.com/gorilla/sessions v1.4.0
+)
+
+require github.com/gorilla/securecookie v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,8 @@
+github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
+github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kXD8ePA=
+github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
+github.com/gorilla/sessions v1.4.0 h1:kpIYOp/oi6MG/p5PgxApU8srsSw9tuFbt46Lt7auzqQ=
+github.com/gorilla/sessions v1.4.0/go.mod h1:FLWm50oby91+hl7p/wRxDth9bWSuk0qVL2emc7lT5ik=

--- a/middleware/csrf.go
+++ b/middleware/csrf.go
@@ -1,0 +1,168 @@
+package middleware
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"log/slog"
+	"net/http"
+	"slices"
+
+	"github.com/gorilla/sessions"
+)
+
+/*
+This implementation relies on a few security assumptions listed below. It passes all tokens in the request/response
+headers and leaves it up to the client to sort out how to handle that. No changes are required in the handlers on the
+go side to implement this, everything is done in the middleware. This implementation doesn't rotate the actual token
+for the duration of the session but does change the token value that is sent to the client by creating a one time pad
+and XORing the static value in the session, then sending that value. The OTP is pre-pended to the XORed value so that
+the server can XOR it back for comparison.
+
+token = <one time pad> <one time pad ^ token>
+
+This XOR operation is not intended as a form of encryption but a protection against the TLS BREACH attack. It is simply
+here to create variation in an otherwise static value without changing the underlying value. This avoids creating a
+situation where the client and server have desynchronized and requests fail. This also means in the event of token
+capture it is possible to recover the original token or perform replay attacks. These replay attacks are limited to the
+duration of the session, however. As an alternative we can implement a token that is not bound to the session such as
+https://medium.com/@jrozner/wiping-out-csrf-ded97ae7e83f.
+
+The design of this is similar to the Rails and Django implementations. More information about the Rails implementation
+can be found https://medium.com/rubyinside/a-deep-dive-into-csrf-protection-in-rails-19fa0a42c0ef.
+
+security assumptions:
+- all communication happens over TLS
+- sessions are opaque to the user (encrypted or stored server side), if not the token will be leaked
+- sessions are tamper resistant (authenticated encryption, key remains secret, or stored server side)
+- all state changing requests never use GET or HEAD requests
+*/
+
+var ErrLengthMismatch = errors.New("xor: length mismatch")
+
+const csrfTokenLength = 32
+
+func xor(a, b []byte) ([]byte, error) {
+	if len(a) != len(b) {
+		return nil, ErrLengthMismatch
+	}
+
+	res := make([]byte, len(a))
+
+	for i := range len(a) {
+		res[i] = a[i] ^ b[i]
+	}
+
+	return res, nil
+}
+
+var safeMethods = []string{http.MethodGet, http.MethodHead, http.MethodTrace}
+
+func CSRF(cookieName string, store sessions.Store) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			var (
+				session             *sessions.Session
+				err                 error
+				token               []byte
+				ok                  bool
+				otp                 []byte
+				maskedToken         []byte
+				tokenEncoded        string
+				requestTokenEncoded string
+				requestToken        []byte
+				unmaskedToken       []byte
+			)
+
+			session, err = store.Get(r, cookieName)
+			if err != nil {
+				slog.ErrorContext(r.Context(), "unable to get session", "error", err)
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			// do we have a csrf token? if not, add one
+			if token, ok = session.Values["CSRFToken"].([]byte); !ok {
+				token = make([]byte, csrfTokenLength)
+				_, err = rand.Read(token)
+				if err != nil {
+					slog.ErrorContext(r.Context(), "unable to generate CSRF token", "error", err)
+					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+					return
+				}
+
+				session.Values["CSRFToken"] = token
+				err = session.Save(r, w)
+				if err != nil {
+					slog.ErrorContext(r.Context(), "unable to save session", "error", err)
+					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+					return
+				}
+			}
+
+			otp = make([]byte, csrfTokenLength)
+			_, err = rand.Read(otp)
+			if err != nil {
+				slog.ErrorContext(r.Context(), "unable to generate csrf otp", "error", err)
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
+			}
+
+			maskedToken, err = xor(token, otp)
+			if err != nil {
+				// this should never happen, it's a bug
+				slog.ErrorContext(r.Context(), "failed to mask token", "error", err)
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
+			}
+
+			tokenEncoded = base64.StdEncoding.EncodeToString(append(otp, maskedToken...))
+			w.Header().Set("X-CSRF-Token", tokenEncoded)
+
+			// if the request uses a safe verb we don't need to check
+			if slices.Contains(safeMethods, r.Method) {
+				goto end
+			}
+
+			// above this should only be fallible from an implementation bug. Below failures can be caused by clients
+			// behaving incorrectly, badly, or malicious requests
+
+			requestTokenEncoded = r.Header.Get("X-CSRF-Token")
+			requestToken, err = base64.StdEncoding.DecodeString(requestTokenEncoded)
+			if err != nil {
+				// incorrectly formed token
+				slog.ErrorContext(r.Context(), "malformed csrf token", "error", err)
+				http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+				return
+			}
+
+			if len(requestToken) != (csrfTokenLength * 2) {
+				slog.ErrorContext(r.Context(), "csrf token wrong size", "expected", csrfTokenLength*2, "actual", len(requestToken))
+				http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+				return
+			}
+
+			unmaskedToken, err = xor(requestToken[:csrfTokenLength], requestToken[csrfTokenLength:])
+			if err != nil {
+				// this shouldn't be possible because we've already confirmed the size. The only error xor() can return
+				// is the wrong size
+				slog.ErrorContext(r.Context(), "failed to unmask token", "error", err)
+				http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+				return
+			}
+
+			if subtle.ConstantTimeCompare(token, unmaskedToken) != 1 {
+				// token doesn't match
+				slog.WarnContext(r.Context(), "csrf token mismatch", "expected", requestToken[csrfTokenLength:], "actual", token)
+				http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+				return
+			}
+
+		end:
+			next.ServeHTTP(w, r)
+		}
+
+		return http.HandlerFunc(fn)
+	}
+}

--- a/middleware/csrf_test.go
+++ b/middleware/csrf_test.go
@@ -1,0 +1,240 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/sessions"
+	"github.com/jrozner/weby"
+)
+
+/*
+tests
+- valid csrf token, unsafe method
+- invalid csrf token (not base64), unsafe method
+- invalid csrf token (wrong size), unsafe method
+- invalid csrf token (mismatch), unsafe method
+- invalid csrf token safe method
+- no csrf token, unsafe method
+- no csrf token, safe method
+*/
+
+func setupCSRFMiddleware(cookieName string, store *sessions.CookieStore) http.Handler {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mux := weby.NewServeMux()
+	mux.Use(Session(cookieName, store))
+	mux.Use(CSRF(cookieName, store))
+	mux.Handle("/test", handler)
+
+	return mux
+}
+
+func TestValidTokenUnsafeMethod(t *testing.T) {
+	store := sessions.NewCookieStore([]byte("test"))
+	mw := setupCSRFMiddleware(defaultCookieName, store)
+
+	r := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, r)
+	r = httptest.NewRequest(http.MethodPost, "/test", nil)
+
+	cookies := w.Result().Cookies()
+	if len(cookies) < 1 {
+		t.Error("no cookies found")
+	}
+
+	// multiple calls to Save on the session will result in multiple cookie headers for the session cookie. In a
+	// browser, the last one will win. That's the behavior we want here
+	last := cookies[len(cookies)-1]
+	r.AddCookie(last)
+
+	r.Header.Add("X-CSRF-Token", w.Result().Header.Get("X-CSRF-Token"))
+
+	w = httptest.NewRecorder()
+
+	mw.ServeHTTP(w, r)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Errorf("request failed with valid session")
+	}
+}
+
+func TestNotBase64TokenUnsafeMethod(t *testing.T) {
+	store := sessions.NewCookieStore([]byte("test"))
+	mw := setupCSRFMiddleware(defaultCookieName, store)
+
+	r := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, r)
+	r = httptest.NewRequest(http.MethodPost, "/test", nil)
+
+	cookies := w.Result().Cookies()
+	if len(cookies) < 1 {
+		t.Error("no cookies found")
+	}
+
+	// multiple calls to Save on the session will result in multiple cookie headers for the session cookie. In a
+	// browser, the last one will win. That's the behavior we want here
+	last := cookies[len(cookies)-1]
+	r.AddCookie(last)
+
+	r.Header.Add("X-CSRF-Token", "~~~BADTOKEN~~~")
+
+	w = httptest.NewRecorder()
+
+	mw.ServeHTTP(w, r)
+
+	if w.Result().StatusCode != http.StatusBadRequest {
+		t.Errorf("malformed token (non-base64) resulted in non-bad request")
+	}
+}
+
+func TestWrongSizeTokenUnsafeMethod(t *testing.T) {
+	store := sessions.NewCookieStore([]byte("test"))
+	mw := setupCSRFMiddleware(defaultCookieName, store)
+
+	r := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, r)
+	r = httptest.NewRequest(http.MethodPost, "/test", nil)
+
+	cookies := w.Result().Cookies()
+	if len(cookies) < 1 {
+		t.Error("no cookies found")
+	}
+
+	// multiple calls to Save on the session will result in multiple cookie headers for the session cookie. In a
+	// browser, the last one will win. That's the behavior we want here
+	last := cookies[len(cookies)-1]
+	r.AddCookie(last)
+
+	r.Header.Add("X-CSRF-Token", "dGVzdA==")
+
+	w = httptest.NewRecorder()
+
+	mw.ServeHTTP(w, r)
+
+	if w.Result().StatusCode != http.StatusBadRequest {
+		t.Errorf("malformed token (wrong size) resulted in non-bad request")
+	}
+}
+
+func TestMismatchTokenUnsafeMethod(t *testing.T) {
+	store := sessions.NewCookieStore([]byte("test"))
+	mw := setupCSRFMiddleware(defaultCookieName, store)
+
+	r := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, r)
+	r = httptest.NewRequest(http.MethodPost, "/test", nil)
+
+	cookies := w.Result().Cookies()
+	if len(cookies) < 1 {
+		t.Error("no cookies found")
+	}
+
+	// multiple calls to Save on the session will result in multiple cookie headers for the session cookie. In a
+	// browser, the last one will win. That's the behavior we want here
+	last := cookies[len(cookies)-1]
+	r.AddCookie(last)
+
+	r.Header.Add("X-CSRF-Token", "sQoZUhVzkCdcXZovQO8SpW052osNlrl0pWCNusT58A2viDdt8lPU7GwGEmYse3mvTA+DstlfyILYKS6yBMlGEQ==")
+
+	w = httptest.NewRecorder()
+
+	mw.ServeHTTP(w, r)
+
+	if w.Result().StatusCode != http.StatusBadRequest {
+		t.Errorf("malformed token (mismatched token) resulted in non-bad request")
+	}
+}
+
+func TestInvalidTokenSafeMethod(t *testing.T) {
+	store := sessions.NewCookieStore([]byte("test"))
+	mw := setupCSRFMiddleware(defaultCookieName, store)
+
+	r := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, r)
+	r = httptest.NewRequest(http.MethodGet, "/test", nil)
+
+	cookies := w.Result().Cookies()
+	if len(cookies) < 1 {
+		t.Error("no cookies found")
+	}
+
+	// multiple calls to Save on the session will result in multiple cookie headers for the session cookie. In a
+	// browser, the last one will win. That's the behavior we want here
+	last := cookies[len(cookies)-1]
+	r.AddCookie(last)
+
+	r.Header.Add("X-CSRF-Token", "sQoZUhVzkCdcXZovQO8SpW052osNlrl0pWCNusT58A2viDdt8lPU7GwGEmYse3mvTA+DstlfyILYKS6yBMlGEQ==")
+
+	w = httptest.NewRecorder()
+
+	mw.ServeHTTP(w, r)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Errorf("invalid token with safe method resulted in non-ok request")
+	}
+}
+
+func TestNoCSRFTokenSafeMethod(t *testing.T) {
+	store := sessions.NewCookieStore([]byte("test"))
+	mw := setupCSRFMiddleware(defaultCookieName, store)
+
+	r := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, r)
+	r = httptest.NewRequest(http.MethodGet, "/test", nil)
+
+	cookies := w.Result().Cookies()
+	if len(cookies) < 1 {
+		t.Error("no cookies found")
+	}
+
+	// multiple calls to Save on the session will result in multiple cookie headers for the session cookie. In a
+	// browser, the last one will win. That's the behavior we want here
+	last := cookies[len(cookies)-1]
+	r.AddCookie(last)
+
+	w = httptest.NewRecorder()
+
+	mw.ServeHTTP(w, r)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Errorf("missing token with safe method resulted in non-ok request")
+	}
+}
+
+func TestNoCSRFTokenUnsafeMethod(t *testing.T) {
+	store := sessions.NewCookieStore([]byte("test"))
+	mw := setupCSRFMiddleware(defaultCookieName, store)
+
+	r := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, r)
+	r = httptest.NewRequest(http.MethodPost, "/test", nil)
+
+	cookies := w.Result().Cookies()
+	if len(cookies) < 1 {
+		t.Error("no cookies found")
+	}
+
+	// multiple calls to Save on the session will result in multiple cookie headers for the session cookie. In a
+	// browser, the last one will win. That's the behavior we want here
+	last := cookies[len(cookies)-1]
+	r.AddCookie(last)
+
+	w = httptest.NewRecorder()
+
+	mw.ServeHTTP(w, r)
+
+	if w.Result().StatusCode != http.StatusBadRequest {
+		t.Errorf("missing token unsafe method resulted in non-bad request")
+	}
+}

--- a/middleware/requestid_test.go
+++ b/middleware/requestid_test.go
@@ -1,0 +1,22 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRequestID(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := r.Context().Value(RequestIDKey).(string); !ok {
+			t.Errorf("request id not set")
+		}
+	})
+
+	mw := RequestID(handler)
+
+	mw.ServeHTTP(w, r)
+}

--- a/middleware/session.go
+++ b/middleware/session.go
@@ -1,0 +1,42 @@
+package middleware
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/gorilla/sessions"
+)
+
+func Session(cookieName string, store sessions.Store) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			session, err := store.Get(r, cookieName)
+			if err != nil {
+				slog.WarnContext(r.Context(), "session cookie invalid", "error", err)
+			}
+
+			// Get will return the session if it exists, a new session if it doesn't exist, and a new session with an
+			// error if it can't be decoded. However, in the event that the cookie name is invalid it will return an
+			// error without a new session (nil). We need to do a nil check to avoid a nil pointer deref on the IsNew
+			// check.
+			if session == nil {
+				slog.ErrorContext(r.Context(), "returned a nil session, bailing out")
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
+			}
+
+			if session.IsNew {
+				err = session.Save(r, w)
+				if err != nil {
+					slog.ErrorContext(r.Context(), "unable to save session")
+					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+					return
+				}
+			}
+
+			next.ServeHTTP(w, r)
+		}
+
+		return http.HandlerFunc(fn)
+	}
+}

--- a/middleware/session_test.go
+++ b/middleware/session_test.go
@@ -1,0 +1,123 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/sessions"
+)
+
+/*
+tests:
+- valid session
+- invalid session
+- no session
+*/
+
+const (
+	defaultCookieName = "SESSION"
+)
+
+func setupSessionMiddleware(cookieName string, store *sessions.CookieStore) http.Handler {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	return Session(cookieName, store)(handler)
+}
+
+func TestSessionValid(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+	store := sessions.NewCookieStore([]byte("test"))
+
+	session, err := store.Get(r, defaultCookieName)
+	if err != nil {
+		t.Errorf("unable to get initial session: %s", err)
+	}
+
+	err = session.Save(r, w)
+	if err != nil {
+		t.Errorf("unable to save session: %s", err)
+	}
+
+	savedCookie, err := http.ParseSetCookie(w.Header().Get("Set-Cookie"))
+	if err != nil {
+		t.Errorf("unable to parse Set-Cookie: %s", err)
+	}
+
+	mw := setupSessionMiddleware(defaultCookieName, store)
+	cookie := http.Cookie{
+		Name:  defaultCookieName,
+		Value: savedCookie.Value,
+	}
+
+	r = httptest.NewRequest(http.MethodGet, "/test", nil)
+	w = httptest.NewRecorder()
+	r.AddCookie(&cookie)
+	mw.ServeHTTP(w, r)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Errorf("request failed with valid session")
+	}
+}
+
+func TestSessionInvalid(t *testing.T) {
+	store := sessions.NewCookieStore([]byte("test"))
+
+	mw := setupSessionMiddleware(defaultCookieName, store)
+	cookie := &http.Cookie{
+		Name:  defaultCookieName,
+		Value: "MTczMTg2NjA5N3xEWDhFQVFMX2dBQUJFQUVRQUFELUJfWF9nQUFFQm5OMGNtbHVad3dOQUF0QlkyTmxjM05VYjJ0bGJnWnpkSEpwYm1jTV9nT1VBUDREa0dWNVNuSmhWMUZwVDJsS2JFOUlRazFpUmxaclVWaEtWMUZWT1daaVZqaDNWR3BLTTFwWVp6Qk9TSEF6VkRCck1tSnFUWGhWVkdRMFlXeHdVVnByYURCUFdFMDBTV2wzYVdSSWJIZEphbTlwV1ZoQ2QySkhiR3BaV0ZKd1lqSTFZMHd5T1hKa1IwVjBZVmMxTUZwWVNuVlpWM2QwV1ZoUmNtRnVaREJKYVhkcFdWZDRia2xxYjJsVmJFMTVUbFJaYVdaUkxtVjVTakphV0VscFQycEZjMGx0Y0RCaFUwazJTV3RHVlV4dGFHbGlWa1pQVVZWb2VsSlhkRkpTYmsweFZWVmFObFF3UmtSaE0yeGhZVEJLUzFoNU1YRmxiWGh0VlRGQ00xZEZSbGhoVkVwbVZFVkZhVXhEU25Cak0wMXBUMmxLYjJSSVVuZGplbTkyVERKU2JHUnBNSGxPYWswd1RrUkplVTE1TlhaaE0xSm9URzFPZG1KVFNYTkpiVVl4V2tOSk5rbHRhREJrU0VKNlQyazRkbHBIVmpKTVZFa3lUWHBSTUUxcVNYcE1iVGx5WkVkRmRWa3lPWFJKYVhkcFl6TldhVWxxYjJsaGJUbHNVVWRTYkZsWFVtbGxXRkpzWTNrMWRWcFlVV2xNUTBwd1dWaFJhVTlxUlROTmVrVTBUbXBaZDA5VVZYTkpiVlkwWTBOSk5rMVVZM3BOVkdjeVQxUlpOVTVUZDJsWk1teHJTV3B2YVUxSE9XaGhNMEkyV1ZoYWJtSkZjRWhpUjJ4UlpHMTNNVnBFWTJsTVEwb3hZVmRSYVU5cFNYZE5TRlp5WTBkV2MwNUhPRE5rTVVwNFkxZE9hRTVFVm10T2VVbHpTVzVPYW1ORFNUWlhlVXAyWTBkV2RXRlhVV2xNUTBwM1kyMDViV0ZYZUd4SmFYZHBXbGN4YUdGWGQybFlVM2RwV1ZoV01HRkdPVEJoVnpGc1NXcHZlRTU2VFhoUFJGa3lUVVJyTUdaUkxrdERXV0pNUldGTFQxVlFjRTFrUjBJd2F6aExjV2h0TUZReldYRnFXalI0YWpkQ2RsSnRRblJtZURSSVNHMVBTVkJNZUVKRU5uUk1WMGxOYXpCNFRtUnBabmxyTkRacldVdzVRVE0wYVRoVFltOTNURGxSU25RMmVsWm9RbTEwVTJwMU1HeGhaR1ZYU1RKUWF6bHliRGhVWjBjNWVscHlSazVYTkc5MmJrSlJVMVoxVTFSR1ltRlZhMVp3YVVJNVlXdHVXa0pFUlhSQ2RGcEVUVVpHTUVkbWIxZENVMFppWTBoSlFrdFNVMWhaVGxWYVNsRlVTVEp0Y25WeE0yTlNZbUk1TUhRMmVGSTJTeTA1TjA4d1pVTjBjVE5rVlZJeFRXSXlORFY2U0hGeVdrczBaR3BKUmpOb1RrWlBMWG81V0RJM01ucE9aMDlmVDBKNmJYcDNObVUxYjBsS2FVeGpRekV0V1hCRFkxRlZjRWMxVDJKV0xWQTVSelJVT1dWNmJ6STVOR2RJVURGWUxXbFZUblpRVG1ObmRWSkdRemx5ZFdWS1luQnFSRUl0Umt0UE1qRk1ibWREUTFJNWNFOTRkVkJqVkdod1VRWnpkSEpwYm1jTUNRQUhTVVJVYjJ0bGJnWnpkSEpwYm1jTV9nUGxBUDRENFdWNVNuSmhWMUZwVDJsS2JFOUlRazFpUmxaclVWaEtWMUZWT1daaVZqaDNWR3BLTTFwWVp6Qk9TSEF6VkRCck1tSnFUWGhWVkdRMFlXeHdVVnByYURCUFdFMDBTV2wzYVZsWGVHNUphbTlwVld4TmVVNVVXV2xtVVM1bGVVcDZaRmRKYVU5cFNYZE5TRlp5WTBkV2MwNUhPRE5rTVVwNFkxZE9hRTVFVm10T2VVbHpTVzAxYUdKWFZXbFBhVXBMWWpKVloxVnRPVFppYlZaNVNXbDNhVnBYTVdoaFYzZHBUMmxLY1dJeVZrRmFSMVpvV2tkS05XUkhWbnBNYlRWc1pFTkpjMGx1V214amFVazJUVk4zYVdGWVRucEphbTlwWVVoU01HTklUVFpNZVRscldsaFpkRTFxV1hwT1JGRjVUV3BOZFdJeWREQlpVelZxWWpJd2FVeERTbWhrVjFGcFQybEpkMkl5Um5KalNIQm9aRzFrYzFOclpITmhWa0l5WWtSV2EwNTVTWE5KYld4b1pFTkpOazFVWTNwTlZHY3lUbXBCTlU1VGQybGFXR2gzU1dwdmVFNTZUWGhQUkZrMVRtcHJNVXhEU25Ga1IydHBUMmxLU2xKRE5XMVVXR3Q2VWpKNFZrMHpaRXhVVkU1d1lsWnNjazB6UW5SVk1XUXdWMFU1YVdWRVFYbFNlVEZ4VEZaR2FFNXJSbEJZTWxKcldXeE9Ta2xwZDJsWlZ6RjVTV3B3WWtsdVFqTmFRMHBrVEVOS2NGcElRV2xQYVVsM1RVYzVjbU5IVm5OT1Iyc3hZVmhGTUZadE9URldSRlpyVG5sSmMwbHROWFppYlU1c1NXcHZhVmt3Y0RCVE0wWjVaSHBrYW1GdFpIaFVNSEJTWldwQ1MxcFZlRU5hZWpBNVNXbDNhV05JU214YWJWWjVZMjFXYTFnelZucGFXRXAxV1ZjeGJFbHFiMmxoYlRsc1VVZFNiRmxYVW1sbFdGSnNZM2sxZFZwWVVXbE1RMHBvWkZoU2IxZ3pVbkJpVjFWcFQycEZNMDE2UlRST2FsbDNUMVJSYzBsdFJqQllNbWhvWXpKbmFVOXBTa3RPTVdnd1pFZEtRMkZZVGxWU2VrSlNWMFZ3ZFZsc1JYaFJNblJ1U1c0d0xuQTBPVTV6ZHkwd2NtdFlNekJOU0RWWFNIZDZlVk5uTFZoblVGOUNlWEZsYW14dWIycFVORGhGTW1aS1l6Wk1Xa1o0VTJwTGJsQTNVRWd4YzBSYVJuSXRaVnB4UWpkaVMwWjFSakpKTUU4eFl6bEdhR3RFUTBGVkxYbFJTRmxyV204eFVWaEtiMVJXUnpneGVsVXpTVnB2TWtSWGNITlVObVpEWkZVdGNrdE1OVXM1UTBwTWVXcGpSbEpQTmxSb2RqTlpTRVpWTFVaeGMwMUZTemxEUzBOUlYyc3RZbmg2U1ZGV1UwWnBhelZGUkhwSFZUWlFiRjl2UzAxNFVGaFFUSEZvYkRjM1RscDBNbE5JVG5WblYxQkdiWEZaVlRWaE1qSlZYMXBvTWpkbmRVaEhiV3BQTUhOTGFuWnBhV0ZoZWxkc2FtaFJNM0pYV2pRNWVtWm1jWGxtTUVOdFJGZEhSWFJsUWtKbFdHOW1kQzF3VWtwWFNWaFhaa1psU1hkeFptRmpiRWw0UzFKa2IwaHRhbTk2UzJSNGRFUm5kRzF5VmxsUmJUQlhkbE53YnpZeE1WQTNabXROTmxVMGNIRXlVVU5xV0ZsSWR3WnpkSEpwYm1jTURBQUtRM1Z6ZEc5dFpYSkpSQVZwYm5Rek1nUUNBQUlHYzNSeWFXNW5EQWdBQmxWelpYSkpSQVZwYm5Rek1nUUNBQUk9fHHXBS8wMYrroaO0I3xm3Ywy6a59H1BzbY5cPWYZbRXa",
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+	r.AddCookie(cookie)
+	mw.ServeHTTP(w, r)
+
+	setCookie := w.Result().Header.Get("Set-Cookie")
+	cookie, err := http.ParseSetCookie(setCookie)
+	if err != nil {
+		t.Errorf("no session cookie returned")
+	}
+
+	if cookie.Name != defaultCookieName {
+		t.Errorf("returned cookie is not a session cookie")
+	}
+}
+
+func TestSessionNone(t *testing.T) {
+	store := sessions.NewCookieStore([]byte("test"))
+
+	mw := setupSessionMiddleware(defaultCookieName, store)
+
+	r := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, r)
+
+	setCookie := w.Result().Header.Get("Set-Cookie")
+	cookie, err := http.ParseSetCookie(setCookie)
+	if err != nil {
+		t.Errorf("no session cookie returned")
+	}
+
+	if cookie.Name != defaultCookieName {
+		t.Errorf("returned cookie is not a session cookie")
+	}
+}
+
+func TestInvalidCookieName(t *testing.T) {
+	store := sessions.NewCookieStore([]byte("test"))
+
+	mw := setupSessionMiddleware("", store)
+
+	r := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, r)
+
+	if w.Result().StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected status code of %d but got %d", http.StatusInternalServerError, w.Result().StatusCode)
+	}
+}

--- a/middleware/value_test.go
+++ b/middleware/value_test.go
@@ -1,0 +1,38 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jrozner/weby/contextvalue"
+)
+
+var (
+	valueTestKey   contextvalue.Key = "hi"
+	valueTestValue                  = "hi"
+)
+
+func TestValue(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var (
+			v   string
+			err error
+		)
+
+		if v, err = contextvalue.Value[string](r.Context(), valueTestKey); err != nil {
+			t.Errorf("error getting value: %s", err)
+		}
+
+		if v != valueTestValue {
+			t.Errorf("want %v, got %v", valueTestValue, v)
+		}
+	})
+
+	mw := Value(valueTestKey, valueTestValue)
+
+	mw(handler).ServeHTTP(w, r)
+}


### PR DESCRIPTION
This adds request id, session, and csrf middleware along with tests. Session middleware is required in order to use the csrf solution and currently uses the gorilla session implementation. We'll probably stick with this for now but it would be nice to completely replace that as well. The gorilla project seems to be semi-unmaintained and unreliable which is the reason for releasing this csrf middleware to begin with. They broke compatibility with the introduction of the origin list which is only necessary for CORS.