### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jrozner/weby/security/code-scanning/3](https://github.com/jrozner/weby/security/code-scanning/3)

In general, the fix is to add an explicit `permissions` block that scopes down the `GITHUB_TOKEN` to the least privileges required. For a simple Go build-and-test workflow that only needs to read the repository contents, `contents: read` is sufficient. This block can be added at the workflow root (so it applies to all jobs) or under the specific job; the minimal and most future-proof approach here is to add it at the top level, just under the `name:` declaration.

Concretely, in `.github/workflows/go.yml`, add:

```yaml
permissions:
  contents: read
```

after line 4 (`name: Go`) and before the `on:` block. No other steps need write access, and we are not adding or removing any actions or behavior, only constraining the token’s capabilities. No imports or external dependencies are required, as this is purely a YAML configuration change within the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
