### PR TITLE
Capture implicit 200 OK in ResponseWrapper

### DIFF
--- a/wrappers/response_wrapper.go
+++ b/wrappers/response_wrapper.go
@@ -14,6 +14,18 @@ func (w *ResponseWrapper) WriteHeader(status int) {
 	w.ResponseWriter.WriteHeader(w.status)
 }
 
+// Write captures the implicit 200 OK that net/http writes when a handler
+// calls Write without first calling WriteHeader. Without this, Status()
+// returns 0 for handlers that don't set a status explicitly, which makes
+// middleware that reports on the status (e.g. request loggers) misreport
+// every successful response as 0.
+func (w *ResponseWrapper) Write(b []byte) (int, error) {
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	return w.ResponseWriter.Write(b)
+}
+
 func (w *ResponseWrapper) Status() int {
 	return w.status
 }

--- a/wrappers/response_wrapper_test.go
+++ b/wrappers/response_wrapper_test.go
@@ -1,0 +1,36 @@
+package wrappers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestStatusCapturedFromWriteHeader(t *testing.T) {
+	w := NewResponseWrapper(httptest.NewRecorder())
+	w.WriteHeader(http.StatusTeapot)
+	if got := w.Status(); got != http.StatusTeapot {
+		t.Errorf("Status() = %d, want %d", got, http.StatusTeapot)
+	}
+}
+
+func TestStatusCapturedFromImplicit200(t *testing.T) {
+	w := NewResponseWrapper(httptest.NewRecorder())
+	if _, err := w.Write([]byte("ok")); err != nil {
+		t.Fatal(err)
+	}
+	if got := w.Status(); got != http.StatusOK {
+		t.Errorf("Status() = %d, want %d (implicit 200 from Write)", got, http.StatusOK)
+	}
+}
+
+func TestExplicitHeaderWinsOverWrite(t *testing.T) {
+	w := NewResponseWrapper(httptest.NewRecorder())
+	w.WriteHeader(http.StatusCreated)
+	if _, err := w.Write([]byte("ok")); err != nil {
+		t.Fatal(err)
+	}
+	if got := w.Status(); got != http.StatusCreated {
+		t.Errorf("Status() = %d, want %d (explicit status must not be overwritten by Write)", got, http.StatusCreated)
+	}
+}


### PR DESCRIPTION
ResponseWrapper only updates its status field inside WriteHeader, so handlers that call Write directly (relying on net/http's implicit 200) leave Status() returning 0. This makes middleware.Logger and any other status-aware middleware misreport every successful response as 0.

Override Write to set status=200 if no explicit status has been written yet. Explicit WriteHeader still takes precedence.