### PR TITLE
template: optional FuncMap parameter for GenerateTemplates

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -25,10 +25,16 @@ var (
 //
 // The base directory name does not matter, but it must not include an underscore as the first character. The base
 // layouts should occur within a directory called _layout in the root templates directory
-func GenerateTemplates(templatesPath string) (map[string]*template.Template, error) {
+//
+// Any optional funcs FuncMaps are registered on the base layout before parsing, so templates may reference them.
+func GenerateTemplates(templatesPath string, funcs ...template.FuncMap) (map[string]*template.Template, error) {
 	templates := make(map[string]*template.Template)
 
-	base := template.Must(template.ParseGlob(path.Join(templatesPath, "_layouts", "*.html")))
+	base := template.New("")
+	for _, f := range funcs {
+		base = base.Funcs(f)
+	}
+	base = template.Must(base.ParseGlob(path.Join(templatesPath, "_layouts", "*.html")))
 
 	err := fs.WalkDir(os.DirFS(templatesPath), ".", func(p string, d fs.DirEntry, err error) error {
 		if d.IsDir() {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1,0 +1,111 @@
+package template
+
+import (
+	"html/template"
+	"net/http/httptest"
+	"os"
+	"path"
+	"strings"
+	"testing"
+)
+
+// writeTree lays down a minimal template tree under a temp dir: a base layout
+// that blocks "body", and a page whose body calls a "humanize" func.
+func writeTree(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	layouts := path.Join(dir, "_layouts")
+	if err := os.MkdirAll(layouts, 0o755); err != nil {
+		t.Fatalf("mkdir layouts: %v", err)
+	}
+
+	pages := path.Join(dir, "pages")
+	if err := os.MkdirAll(pages, 0o755); err != nil {
+		t.Fatalf("mkdir pages: %v", err)
+	}
+
+	if err := os.WriteFile(path.Join(layouts, "base.html"), []byte(`{{define "base"}}{{block "body" .}}{{end}}{{end}}`), 0o644); err != nil {
+		t.Fatalf("write base.html: %v", err)
+	}
+
+	if err := os.WriteFile(path.Join(pages, "index.html"), []byte(`{{define "body"}}{{humanize .Value}}{{end}}`), 0o644); err != nil {
+		t.Fatalf("write index.html: %v", err)
+	}
+
+	return dir
+}
+
+// TestGenerateTemplatesFuncMap verifies that a custom FuncMap is registered on
+// the base layout so pages that reference the func parse and execute correctly.
+func TestGenerateTemplatesFuncMap(t *testing.T) {
+	dir := writeTree(t)
+
+	funcs := template.FuncMap{
+		"humanize": func(s string) string { return "HUMAN:" + s },
+	}
+
+	templates, err := GenerateTemplates(dir, funcs)
+	if err != nil {
+		t.Fatalf("GenerateTemplates: %v", err)
+	}
+
+	key := "pages/index.html"
+	if _, ok := templates[key]; !ok {
+		t.Fatalf("expected template map to contain key %q, got keys %v", key, keysOf(templates))
+	}
+
+	rec := httptest.NewRecorder()
+	data := struct{ Value string }{Value: "world"}
+	if err := Render(rec, 200, templates, key, "base", data); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	if got := rec.Body.String(); !strings.Contains(got, "HUMAN:world") {
+		t.Fatalf("expected output to contain %q, got %q", "HUMAN:world", got)
+	}
+}
+
+// TestGenerateTemplatesNoFuncs verifies the backward-compatible no-funcs call
+// still succeeds and produces the expected page key.
+func TestGenerateTemplatesNoFuncs(t *testing.T) {
+	dir := t.TempDir()
+
+	layouts := path.Join(dir, "_layouts")
+	if err := os.MkdirAll(layouts, 0o755); err != nil {
+		t.Fatalf("mkdir layouts: %v", err)
+	}
+
+	pages := path.Join(dir, "pages")
+	if err := os.MkdirAll(pages, 0o755); err != nil {
+		t.Fatalf("mkdir pages: %v", err)
+	}
+
+	if err := os.WriteFile(path.Join(layouts, "base.html"), []byte(`{{define "base"}}{{block "body" .}}{{end}}{{end}}`), 0o644); err != nil {
+		t.Fatalf("write base.html: %v", err)
+	}
+
+	// A page that does not reference any custom func, so it parses without a FuncMap.
+	if err := os.WriteFile(path.Join(pages, "index.html"), []byte(`{{define "body"}}plain{{end}}`), 0o644); err != nil {
+		t.Fatalf("write index.html: %v", err)
+	}
+
+	templates, err := GenerateTemplates(dir)
+	if err != nil {
+		t.Fatalf("GenerateTemplates: %v", err)
+	}
+
+	key := "pages/index.html"
+	if _, ok := templates[key]; !ok {
+		t.Fatalf("expected template map to contain key %q, got keys %v", key, keysOf(templates))
+	}
+}
+
+func keysOf(m map[string]*template.Template) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}


### PR DESCRIPTION
## What
Make `template.GenerateTemplates` accept optional `template.FuncMap`s (variadic), registered on the base layout before parsing so pages/layouts can reference custom template funcs.

```go
func GenerateTemplates(templatesPath string, funcs ...template.FuncMap) (map[string]*template.Template, error)
```

## Why
Downstream apps that need an app-specific template func (e.g. a `humanize` filter for display labels) currently have to **reimplement this function's entire walk** — parse the `_layouts` glob, `WalkDir`, clone the base, `ParseFiles` — purely to slip in a `.Funcs()` call on the base. That duplicated walk silently drifts from this one if template discovery ever changes. Exposing the FuncMap hook here removes that duplication.

## Backward compatible
Variadic parameter — every existing `GenerateTemplates(dir)` caller compiles and behaves identically. The no-funcs path (`template.New("").ParseGlob(...)` under `template.Must`) is equivalent to the previous `template.Must(template.ParseGlob(...))`; layouts are addressed by their `{{define}}` names, so the empty root name is irrelevant.

## Tests (new — `template/template_test.go`, none existed)
- `TestGenerateTemplatesFuncMap`: registers a `humanize` func, renders a page that calls it through the public `Render`, asserts the output — proves the func is on the base before the per-page clone.
- `TestGenerateTemplatesNoFuncs`: backward-compat, a page with no custom func.
- `gofmt`/`vet`/`build`/`test ./...` all green.

## Follow-up
After merge, tag a release (**v0.3.0**) so `overemployed` can bump its `go.mod` and collapse its `internal/render.New` back to a one-liner. Context: jrozner/overemployed#28 (discussion_r3525542573).
